### PR TITLE
Add database 'host' parameter to the configuration array

### DIFF
--- a/databasefiller.class.php
+++ b/databasefiller.class.php
@@ -110,7 +110,7 @@ class DatabaseFiller {
 
 		if ( ! $this->bDebug) {
 
-			if ( ! isset($aConfig['database']) || ! isset($aConfig['username']) || ! isset($aConfig['password'])) {
+			if ( ! isset($aConfig['host']) || ! isset($aConfig['database']) || ! isset($aConfig['username']) || ! isset($aConfig['password'])) {
 
 				$this->aMessages[] = 'Database connection details have not been fully specified in the configuration array.';
 				return;
@@ -120,7 +120,7 @@ class DatabaseFiller {
 				$this->sEncoding = $aConfig['encoding'];
 			}
 
-			$this->oConnection = new mysqli('localhost', $aConfig['username'], $aConfig['password'], $aConfig['database']);
+			$this->oConnection = new mysqli($aConfig['host'], $aConfig['username'], $aConfig['password'], $aConfig['database']);
 
 			if ( ! $this->oConnection->connect_errno) {
 

--- a/databasefiller_example.php
+++ b/databasefiller_example.php
@@ -31,7 +31,7 @@ $aConfiguration = [
 		// optimise mysqld variables in my.cnf/my.ini files when inserting a large number of rows (e.g. 50000)
 
 	# database details
-    'host'     => 'localhost',
+	'host'     => 'localhost',
 	'database' => 'dbfilltest',
 	'username' => 'USERNAME',
 	'password' => 'PASSWORD',

--- a/databasefiller_example.php
+++ b/databasefiller_example.php
@@ -31,6 +31,7 @@ $aConfiguration = [
 		// optimise mysqld variables in my.cnf/my.ini files when inserting a large number of rows (e.g. 50000)
 
 	# database details
+    'host'     => 'localhost',
 	'database' => 'dbfilltest',
 	'username' => 'USERNAME',
 	'password' => 'PASSWORD',


### PR DESCRIPTION
Hey there! Thank you for this great tool. That was exactly what I was looking for.

I've just added a 'host' parameter to the configuration array, so we can use a different host from 'localhost', as we usually do while working with Docker.

It's a minimal change and everything is still working accordingly.